### PR TITLE
Fix ios webmin

### DIFF
--- a/glslang/Include/BaseTypes.h
+++ b/glslang/Include/BaseTypes.h
@@ -66,10 +66,8 @@ enum TBasicType {
     EbtReference,
     EbtRayQuery,
     EbtHitObjectNV,
-#ifndef GLSLANG_WEB
     // SPIR-V type defined by spirv_type
     EbtSpirvType,
-#endif
 
     // HLSL types that live only temporarily.
     EbtString,
@@ -96,9 +94,7 @@ enum TStorageQualifier {
     EvqUniform,       // read only, shared with app
     EvqBuffer,        // read/write, shared with app
     EvqShared,        // compute shader's read/write 'shared' qualifier
-#ifndef GLSLANG_WEB
     EvqSpirvStorageClass, // spirv_storage_class
-#endif
 
     EvqPayload,
     EvqPayloadIn,
@@ -341,10 +337,6 @@ enum TPrecisionQualifier {
     EpqHigh
 };
 
-#ifdef GLSLANG_WEB
-__inline const char* GetStorageQualifierString(TStorageQualifier) { return ""; }
-__inline const char* GetPrecisionQualifierString(TPrecisionQualifier) { return ""; }
-#else
 // These will show up in error messages
 __inline const char* GetStorageQualifierString(TStorageQualifier q)
 {
@@ -353,9 +345,7 @@ __inline const char* GetStorageQualifierString(TStorageQualifier q)
     case EvqGlobal:         return "global";         break;
     case EvqConst:          return "const";          break;
     case EvqConstReadOnly:  return "const (read only)"; break;
-#ifndef GLSLANG_WEB
     case EvqSpirvStorageClass: return "spirv_storage_class"; break;
-#endif
     case EvqVaryingIn:      return "in";             break;
     case EvqVaryingOut:     return "out";            break;
     case EvqUniform:        return "uniform";        break;
@@ -546,7 +536,6 @@ __inline const char* GetPrecisionQualifierString(TPrecisionQualifier p)
     default:        return "unknown precision qualifier";
     }
 }
-#endif
 
 __inline bool isTypeSignedInt(TBasicType type)
 {

--- a/glslang/Include/SpirvIntrinsics.h
+++ b/glslang/Include/SpirvIntrinsics.h
@@ -35,8 +35,6 @@
 
 #pragma once
 
-#ifndef GLSLANG_WEB
-
 //
 // GL_EXT_spirv_intrinsics
 //
@@ -135,5 +133,3 @@ struct TSpirvType {
 };
 
 } // end namespace glslang
-
-#endif // GLSLANG_WEB

--- a/glslang/Include/Types.h
+++ b/glslang/Include/Types.h
@@ -86,21 +86,7 @@ struct TSampler {   // misnomer now; includes images, textures without sampler, 
     bool   combined : 1;  // true means texture is combined with a sampler, false means texture with no sampler
     bool    sampler : 1;  // true means a pure sampler, other fields should be clear()
 
-#ifdef GLSLANG_WEB
-    bool is1D()          const { return false; }
-    bool is2D()          const { return dim == Esd2D; }
-    bool isBuffer()      const { return false; }
-    bool isRect()        const { return false; }
-    bool isSubpass()     const { return false; }
-    bool isAttachmentEXT()  const { return false; }
-    bool isCombined()    const { return true; }
-    bool isImage()       const { return false; }
-    bool isImageClass()  const { return false; }
-    bool isMultiSample() const { return false; }
-    bool isExternal()    const { return false; }
-    void setExternal(bool) { }
-    bool isYuv()         const { return false; }
-#else
+
     unsigned int vectorSize : 3;  // vector return type size.
     // Some languages support structures as sample results.  Storing the whole structure in the
     // TSampler is too large, so there is an index to a separate table.
@@ -133,7 +119,6 @@ struct TSampler {   // misnomer now; includes images, textures without sampler, 
     bool isExternal()    const { return external; }
     void setExternal(bool e) { external = e; }
     bool isYuv()         const { return yuv; }
-#endif
     bool isTexture()     const { return !sampler && !image; }
     bool isPureSampler() const { return sampler; }
 
@@ -153,10 +138,8 @@ struct TSampler {   // misnomer now; includes images, textures without sampler, 
         image = false;
         combined = false;
         sampler = false;
-#ifndef GLSLANG_WEB
         external = false;
         yuv = false;
-#endif
 
 #ifdef ENABLE_HLSL
         clearReturnStruct();
@@ -208,7 +191,6 @@ struct TSampler {   // misnomer now; includes images, textures without sampler, 
         shadow = s;
     }
 
-#ifndef GLSLANG_WEB
     // make a subpass input attachment
     void setSubpass(TBasicType t, bool m = false)
     {
@@ -227,7 +209,6 @@ struct TSampler {   // misnomer now; includes images, textures without sampler, 
         image = true;
         dim = EsdAttachmentEXT;
     }
-#endif
 
     bool operator==(const TSampler& right) const
     {
@@ -265,7 +246,6 @@ struct TSampler {   // misnomer now; includes images, textures without sampler, 
         switch (type) {
         case EbtInt:    s.append("i");   break;
         case EbtUint:   s.append("u");   break;
-#ifndef GLSLANG_WEB
         case EbtFloat16: s.append("f16"); break;
         case EbtInt8:   s.append("i8");  break;
         case EbtUint16: s.append("u8");  break;
@@ -273,7 +253,6 @@ struct TSampler {   // misnomer now; includes images, textures without sampler, 
         case EbtUint8:  s.append("u16"); break;
         case EbtInt64:  s.append("i64"); break;
         case EbtUint64: s.append("u64"); break;
-#endif
         default:  break;
         }
         if (isImageClass()) {
@@ -299,13 +278,11 @@ struct TSampler {   // misnomer now; includes images, textures without sampler, 
         case Esd2D:      s.append("2D");      break;
         case Esd3D:      s.append("3D");      break;
         case EsdCube:    s.append("Cube");    break;
-#ifndef GLSLANG_WEB
         case Esd1D:         s.append("1D");      break;
         case EsdRect:       s.append("2DRect");  break;
         case EsdBuffer:     s.append("Buffer");  break;
         case EsdSubpass:    s.append("Input"); break;
         case EsdAttachmentEXT: s.append(""); break;
-#endif
         default:  break;  // some compilers want this
         }
         if (isMultiSample())
@@ -534,12 +511,10 @@ public:
         invariant = false;
         makeTemporary();
         declaredBuiltIn = EbvNone;
-#ifndef GLSLANG_WEB
         noContraction = false;
         nullInit = false;
         spirvByReference = false;
         spirvLiteral = false;
-#endif
         defaultBlock = false;
     }
 
@@ -555,22 +530,18 @@ public:
         nonUniform = false;
         defaultBlock = false;
         clearLayout();
-#ifndef GLSLANG_WEB
         spirvStorageClass = -1;
         spirvDecorate = nullptr;
         spirvByReference = false;
         spirvLiteral = false;
         nullInit = false;
-#endif
     }
 
     void clearInterstage()
     {
         clearInterpolation();
-#ifndef GLSLANG_WEB
         patch = false;
         sample = false;
-#endif
     }
 
     void clearInterpolation()
@@ -578,7 +549,6 @@ public:
         centroid     = false;
         smooth       = false;
         flat         = false;
-#ifndef GLSLANG_WEB
         nopersp      = false;
         explicitInterp = false;
         pervertexNV = false;
@@ -586,12 +556,10 @@ public:
         perViewNV = false;
         perTaskNV = false;
         pervertexEXT = false;
-#endif
     }
 
     void clearMemory()
     {
-#ifndef GLSLANG_WEB
         coherent     = false;
         devicecoherent = false;
         queuefamilycoherent = false;
@@ -603,7 +571,6 @@ public:
         restrict     = false;
         readonly     = false;
         writeonly    = false;
-#endif
     }
 
     const char*         semanticName;
@@ -622,31 +589,6 @@ public:
     bool explicitOffset   : 1;
     bool defaultBlock : 1; // default blocks with matching names have structures merged when linking
 
-#ifdef GLSLANG_WEB
-    bool isWriteOnly() const { return false; }
-    bool isReadOnly() const { return false; }
-    bool isRestrict() const { return false; }
-    bool isCoherent() const { return false; }
-    bool isVolatile() const { return false; }
-    bool isSample() const { return false; }
-    bool isMemory() const { return false; }
-    bool isMemoryQualifierImageAndSSBOOnly() const { return false; }
-    bool bufferReferenceNeedsVulkanMemoryModel() const { return false; }
-    bool isInterpolation() const { return flat || smooth; }
-    bool isExplicitInterpolation() const { return false; }
-    bool isAuxiliary() const { return centroid; }
-    bool isPatch() const { return false; }
-    bool isNoContraction() const { return false; }
-    void setNoContraction() { }
-    bool isPervertexNV() const { return false; }
-    bool isPervertexEXT() const { return false; }
-    void setNullInit() {}
-    bool isNullInit() const { return false; }
-    void setSpirvByReference() { }
-    bool isSpirvByReference() { return false; }
-    void setSpirvLiteral() { }
-    bool isSpirvLiteral() { return false; }
-#else
     bool noContraction: 1; // prevent contraction and reassociation, e.g., for 'precise' keyword, and expressions it affects
     bool nopersp      : 1;
     bool explicitInterp : 1;
@@ -713,7 +655,6 @@ public:
     bool isSpirvByReference() const { return spirvByReference; }
     void setSpirvLiteral() { spirvLiteral = true; }
     bool isSpirvLiteral() const { return spirvLiteral; }
-#endif
 
     bool isPipeInput() const
     {
@@ -844,9 +785,7 @@ public:
     }
 
     void setBlockStorage(TBlockStorageClass newBacking) {
-#ifndef GLSLANG_WEB
         layoutPushConstant = (newBacking == EbsPushConstant);
-#endif
         switch (newBacking) {
         case EbsUniform :
             if (layoutPacking == ElpStd430) {
@@ -858,23 +797,17 @@ public:
         case EbsStorageBuffer :
             storage = EvqBuffer;
             break;
-#ifndef GLSLANG_WEB
         case EbsPushConstant :
             storage = EvqUniform;
             layoutSet = TQualifier::layoutSetEnd;
             layoutBinding = TQualifier::layoutBindingEnd;
             break;
-#endif
         default:
             break;
         }
     }
 
-#ifdef GLSLANG_WEB
-    bool isPerView() const { return false; }
-    bool isTaskMemory() const { return false; }
-    bool isArrayedIo(EShLanguage) const { return false; }
-#else
+
     bool isPerPrimitive() const { return perPrimitiveNV; }
     bool isPerView() const { return perViewNV; }
     bool isTaskMemory() const { return perTaskNV; }
@@ -908,14 +841,12 @@ public:
             return false;
         }
     }
-#endif
 
     // Implementing an embedded layout-qualifier class here, since C++ can't have a real class bitfield
     void clearLayout()  // all layout
     {
         clearUniformLayout();
 
-#ifndef GLSLANG_WEB
         layoutPushConstant = false;
         layoutBufferReference = false;
         layoutPassthrough = false;
@@ -928,7 +859,6 @@ public:
         layoutBindlessImage = false;
         layoutBufferReferenceAlign = layoutBufferReferenceAlignEnd;
         layoutFormat = ElfNone;
-#endif
 
         clearInterstageLayout();
 
@@ -938,14 +868,11 @@ public:
     {
         layoutLocation = layoutLocationEnd;
         layoutComponent = layoutComponentEnd;
-#ifndef GLSLANG_WEB
         layoutIndex = layoutIndexEnd;
         clearStreamLayout();
         clearXfbLayout();
-#endif
     }
 
-#ifndef GLSLANG_WEB
     void clearStreamLayout()
     {
         layoutStream = layoutStreamEnd;
@@ -956,7 +883,6 @@ public:
         layoutXfbStride = layoutXfbStrideEnd;
         layoutXfbOffset = layoutXfbOffsetEnd;
     }
-#endif
 
     bool hasNonXfbLayout() const
     {
@@ -1012,7 +938,6 @@ public:
                  unsigned int layoutSpecConstantId       : 11;
     static const unsigned int layoutSpecConstantIdEnd = 0x7FF;
 
-#ifndef GLSLANG_WEB
     // stored as log2 of the actual alignment value
                  unsigned int layoutBufferReferenceAlign :  6;
     static const unsigned int layoutBufferReferenceAlignEnd = 0x3F;
@@ -1033,7 +958,6 @@ public:
 
     bool layoutBindlessSampler;
     bool layoutBindlessImage;
-#endif
 
     bool hasUniformLayout() const
     {
@@ -1053,9 +977,7 @@ public:
 
         layoutSet = layoutSetEnd;
         layoutBinding = layoutBindingEnd;
-#ifndef GLSLANG_WEB
         layoutAttachment = layoutAttachmentEnd;
-#endif
     }
 
     bool hasMatrix() const
@@ -1088,26 +1010,6 @@ public:
     {
         return layoutBinding != layoutBindingEnd;
     }
-#ifdef GLSLANG_WEB
-    bool hasOffset() const { return false; }
-    bool isNonPerspective() const { return false; }
-    bool hasIndex() const { return false; }
-    unsigned getIndex() const { return 0; }
-    bool hasComponent() const { return false; }
-    bool hasStream() const { return false; }
-    bool hasFormat() const { return false; }
-    bool hasXfb() const { return false; }
-    bool hasXfbBuffer() const { return false; }
-    bool hasXfbStride() const { return false; }
-    bool hasXfbOffset() const { return false; }
-    bool hasAttachment() const { return false; }
-    TLayoutFormat getFormat() const { return ElfNone; }
-    bool isPushConstant() const { return false; }
-    bool isShaderRecord() const { return false; }
-    bool hasBufferReference() const { return false; }
-    bool hasBufferReferenceAlign() const { return false; }
-    bool isNonUniform() const { return false; }
-#else
     bool hasOffset() const
     {
         return layoutOffset != layoutNotSet;
@@ -1182,7 +1084,7 @@ public:
     const TSpirvDecorate& getSpirvDecorate() const { assert(spirvDecorate); return *spirvDecorate; }
     TSpirvDecorate& getSpirvDecorate() { assert(spirvDecorate); return *spirvDecorate; }
     TString getSpirvDecorateQualifierString() const;
-#endif
+
     bool hasSpecConstantId() const
     {
         // Not the same thing as being a specialization constant, this
@@ -1216,12 +1118,10 @@ public:
     {
         switch (packing) {
         case ElpStd140:   return "std140";
-#ifndef GLSLANG_WEB
         case ElpPacked:   return "packed";
         case ElpShared:   return "shared";
         case ElpStd430:   return "std430";
         case ElpScalar:   return "scalar";
-#endif
         default:          return "none";
         }
     }
@@ -1233,9 +1133,6 @@ public:
         default:             return "none";
         }
     }
-#ifdef GLSLANG_WEB
-    static const char* getLayoutFormatString(TLayoutFormat) { return "none"; }
-#else
     static const char* getLayoutFormatString(TLayoutFormat f)
     {
         switch (f) {
@@ -1389,7 +1286,6 @@ public:
         default:                                return "none";
         }
     }
-#endif
 };
 
 // Qualifiers that don't need to be keep per object.  They have shader scope, not object scope.
@@ -1406,7 +1302,6 @@ struct TShaderQualifiers {
     int localSize[3];         // compute shader
     bool localSizeNotDefault[3];        // compute shader
     int localSizeSpecId[3];   // compute shader specialization id for gl_WorkGroupSize
-#ifndef GLSLANG_WEB
     bool earlyFragmentTests;  // fragment input
     bool postDepthCoverage;   // fragment input
     bool earlyAndLateFragmentTestsAMD; //fragment input
@@ -1425,10 +1320,6 @@ struct TShaderQualifiers {
     bool layoutPrimitiveCulling;        // true if layout primitive_culling set
     TLayoutDepth getDepth() const { return layoutDepth; }
     TLayoutStencil getStencil() const { return layoutStencil; }
-#else
-    TLayoutDepth getDepth() const { return EldNone; }
-    TLayoutStencil getStencil() const { return ElsNone; }
-#endif
 
     void init()
     {
@@ -1449,7 +1340,6 @@ struct TShaderQualifiers {
         localSizeSpecId[0] = TQualifier::layoutNotSet;
         localSizeSpecId[1] = TQualifier::layoutNotSet;
         localSizeSpecId[2] = TQualifier::layoutNotSet;
-#ifndef GLSLANG_WEB
         earlyFragmentTests = false;
         earlyAndLateFragmentTestsAMD = false;
         postDepthCoverage = false;
@@ -1466,14 +1356,9 @@ struct TShaderQualifiers {
         layoutPrimitiveCulling      = false;
         primitives                  = TQualifier::layoutNotSet;
         interlockOrdering = EioNone;
-#endif
     }
 
-#ifdef GLSLANG_WEB
-    bool hasBlendEquation() const { return false; }
-#else
     bool hasBlendEquation() const { return blendEquation; }
-#endif
 
     // Merge in characteristics from the 'src' qualifier.  They can override when
     // set, but never erase when not set.
@@ -1506,7 +1391,6 @@ struct TShaderQualifiers {
             if (src.localSizeSpecId[i] != TQualifier::layoutNotSet)
                 localSizeSpecId[i] = src.localSizeSpecId[i];
         }
-#ifndef GLSLANG_WEB
         if (src.earlyFragmentTests)
             earlyFragmentTests = true;
         if (src.earlyAndLateFragmentTestsAMD)
@@ -1539,7 +1423,6 @@ struct TShaderQualifiers {
             interlockOrdering = src.interlockOrdering;
         if (src.layoutPrimitiveCulling)
             layoutPrimitiveCulling = src.layoutPrimitiveCulling;
-#endif
     }
 };
 
@@ -1565,16 +1448,11 @@ public:
     const TType* userDef;
     TSourceLoc loc;
     TArraySizes* typeParameters;
-#ifndef GLSLANG_WEB
     // SPIR-V type defined by spirv_type directive
     TSpirvType* spirvType;
-#endif
 
-#ifdef GLSLANG_WEB
-    bool isCoopmat() const { return false; }
-#else
+
     bool isCoopmat() const { return coopmat; }
-#endif
 
     void initType(const TSourceLoc& l)
     {
@@ -1587,9 +1465,8 @@ public:
         loc = l;
         typeParameters = nullptr;
         coopmat = false;
-#ifndef GLSLANG_WEB
         spirvType = nullptr;
-#endif
+
     }
 
     void initQualifiers(bool global = false)
@@ -1626,10 +1503,8 @@ public:
         return matrixCols == 0 && vectorSize == 1 && arraySizes == nullptr && userDef == nullptr;
     }
 
-#ifndef GLSLANG_WEB
     // GL_EXT_spirv_intrinsics
     void setSpirvType(const TSpirvInstruction& spirvInst, const TSpirvTypeParameters* typeParams = nullptr);
-#endif
 
     // "Image" is a superset of "Subpass"
     bool isImage()      const { return basicType == EbtSampler && sampler.isImage(); }
@@ -1649,9 +1524,7 @@ public:
                    bool isVector = false) :
                             basicType(t), vectorSize(vs), matrixCols(mc), matrixRows(mr), vector1(isVector && vs == 1), coopmat(false),
                             arraySizes(nullptr), structure(nullptr), fieldName(nullptr), typeName(nullptr), typeParameters(nullptr)
-#ifndef GLSLANG_WEB
                             , spirvType(nullptr)
-#endif
                             {
                                 sampler.clear();
                                 qualifier.clear();
@@ -1663,9 +1536,7 @@ public:
           bool isVector = false) :
                             basicType(t), vectorSize(vs), matrixCols(mc), matrixRows(mr), vector1(isVector && vs == 1), coopmat(false),
                             arraySizes(nullptr), structure(nullptr), fieldName(nullptr), typeName(nullptr), typeParameters(nullptr)
-#ifndef GLSLANG_WEB
                             , spirvType(nullptr)
-#endif
                             {
                                 sampler.clear();
                                 qualifier.clear();
@@ -1679,9 +1550,7 @@ public:
                             basicType(p.basicType),
                             vectorSize(p.vectorSize), matrixCols(p.matrixCols), matrixRows(p.matrixRows), vector1(false), coopmat(p.coopmat),
                             arraySizes(p.arraySizes), structure(nullptr), fieldName(nullptr), typeName(nullptr), typeParameters(p.typeParameters)
-#ifndef GLSLANG_WEB
                             , spirvType(p.spirvType)
-#endif
                             {
                                 if (basicType == EbtSampler)
                                     sampler = p.sampler;
@@ -1716,9 +1585,7 @@ public:
         basicType(EbtSampler), vectorSize(1), matrixCols(0), matrixRows(0), vector1(false), coopmat(false),
         arraySizes(as), structure(nullptr), fieldName(nullptr), typeName(nullptr),
         sampler(sampler), typeParameters(nullptr)
-#ifndef GLSLANG_WEB
         , spirvType(nullptr)
-#endif
     {
         qualifier.clear();
         qualifier.storage = q;
@@ -1769,9 +1636,7 @@ public:
     TType(TTypeList* userDef, const TString& n) :
                             basicType(EbtStruct), vectorSize(1), matrixCols(0), matrixRows(0), vector1(false), coopmat(false),
                             arraySizes(nullptr), structure(userDef), fieldName(nullptr), typeParameters(nullptr)
-#ifndef GLSLANG_WEB
                             , spirvType(nullptr)
-#endif
                             {
                                 sampler.clear();
                                 qualifier.clear();
@@ -1781,9 +1646,7 @@ public:
     TType(TTypeList* userDef, const TString& n, const TQualifier& q) :
                             basicType(EbtBlock), vectorSize(1), matrixCols(0), matrixRows(0), vector1(false), coopmat(false),
                             qualifier(q), arraySizes(nullptr), structure(userDef), fieldName(nullptr), typeParameters(nullptr)
-#ifndef GLSLANG_WEB
                             , spirvType(nullptr)
-#endif
                             {
                                 sampler.clear();
                                 typeName = NewPoolTString(n.c_str());
@@ -1792,9 +1655,7 @@ public:
     explicit TType(TBasicType t, const TType &p, const TString& n) :
                             basicType(t), vectorSize(1), matrixCols(0), matrixRows(0), vector1(false), coopmat(false),
                             arraySizes(nullptr), structure(nullptr), fieldName(nullptr), typeName(nullptr), typeParameters(nullptr)
-#ifndef GLSLANG_WEB
                             , spirvType(nullptr)
-#endif
                             {
                                 assert(t == EbtReference);
                                 typeName = NewPoolTString(n.c_str());
@@ -1826,9 +1687,7 @@ public:
             referentType = copyOf.referentType;
         }
         typeParameters = copyOf.typeParameters;
-#ifndef GLSLANG_WEB
         spirvType = copyOf.spirvType;
-#endif
         coopmat = copyOf.isCoopMat();
     }
 
@@ -1905,11 +1764,7 @@ public:
     virtual int getOuterArraySize()  const { return arraySizes->getOuterSize(); }
     virtual TIntermTyped*  getOuterArrayNode() const { return arraySizes->getOuterNode(); }
     virtual int getCumulativeArraySize()  const { return arraySizes->getCumulativeSize(); }
-#ifdef GLSLANG_WEB
-    bool isArrayOfArrays() const { return false; }
-#else
     bool isArrayOfArrays() const { return arraySizes != nullptr && arraySizes->getNumDims() > 1; }
-#endif
     virtual int getImplicitArraySize() const { return arraySizes->getImplicitSize(); }
     virtual const TArraySizes* getArraySizes() const { return arraySizes; }
     virtual       TArraySizes* getArraySizes()       { return arraySizes; }
@@ -1951,10 +1806,8 @@ public:
         return false;
     }
     virtual bool isOpaque() const { return basicType == EbtSampler
-#ifndef GLSLANG_WEB
             || basicType == EbtAtomicUint || basicType == EbtAccStruct || basicType == EbtRayQuery 
             || basicType == EbtHitObjectNV
-#endif
         ; }
     virtual bool isBuiltIn() const { return getQualifier().builtIn != EbvNone; }
 
@@ -1963,27 +1816,15 @@ public:
     virtual bool isSubpass() const { return basicType == EbtSampler && getSampler().isSubpass(); }
     virtual bool isTexture() const { return basicType == EbtSampler && getSampler().isTexture(); }
 
-#ifdef GLSLANG_WEB
-    virtual bool isBindlessImage() const { return false; }
-    virtual bool isBindlessTexture() const { return false; }
-#else
     virtual bool isBindlessImage() const { return isImage() && qualifier.layoutBindlessImage; }
     virtual bool isBindlessTexture() const { return isTexture() && qualifier.layoutBindlessSampler; }
-#endif
     // Check the block-name convention of creating a block without populating it's members:
     virtual bool isUnusableName() const { return isStruct() && structure == nullptr; }
     virtual bool isParameterized()  const { return typeParameters != nullptr; }
-#ifdef GLSLANG_WEB
-    bool isAtomic() const { return false; }
-    bool isCoopMat() const { return false; }
-    bool isReference() const { return false; }
-    bool isSpirvType() const { return false; }
-#else
     bool isAtomic() const { return basicType == EbtAtomicUint; }
     bool isCoopMat() const { return coopmat; }
     bool isReference() const { return getBasicType() == EbtReference; }
     bool isSpirvType() const { return getBasicType() == EbtSpirvType; }
-#endif
 
     // return true if this type contains any subtype which satisfies the given predicate.
     template <typename P>
@@ -2069,15 +1910,6 @@ public:
         return contains([](const TType* t) { return t->isArray() && t->arraySizes->isOuterSpecialization(); } );
     }
 
-#ifdef GLSLANG_WEB
-    bool containsDouble() const { return false; }
-    bool contains16BitFloat() const { return false; }
-    bool contains64BitInt() const { return false; }
-    bool contains16BitInt() const { return false; }
-    bool contains8BitInt() const { return false; }
-    bool containsCoopMat() const { return false; }
-    bool containsReference() const { return false; }
-#else
     bool containsDouble() const
     {
         return containsBasicType(EbtDouble);
@@ -2106,7 +1938,6 @@ public:
     {
         return containsBasicType(EbtReference);
     }
-#endif
 
     // Array editing methods.  Array descriptors can be shared across
     // type instances.  This allows all uses of the same array
@@ -2232,7 +2063,6 @@ public:
         case EbtInt:               return "int";
         case EbtUint:              return "uint";
         case EbtSampler:           return "sampler/image";
-#ifndef GLSLANG_WEB
         case EbtVoid:              return "void";
         case EbtDouble:            return "double";
         case EbtFloat16:           return "float16_t";
@@ -2251,22 +2081,10 @@ public:
         case EbtReference:         return "reference";
         case EbtString:            return "string";
         case EbtSpirvType:         return "spirv_type";
-#endif
         default:                   return "unknown type";
         }
     }
 
-#ifdef GLSLANG_WEB
-    TString getCompleteString(bool = false, bool = true, bool = true,
-                              bool = true, TString = "", TString = "") const
-    {
-        return "";
-    }
-    const char* getStorageQualifierString() const { return ""; }
-    const char* getBuiltInVariableString() const { return ""; }
-    const char* getPrecisionQualifierString() const { return ""; }
-    TString getBasicTypeString() const { return ""; }
-#else
     TString getCompleteString(bool syntactic = false, bool getQualifiers = true, bool getPrecision = true,
                               bool getType = true, TString name = "", TString structName = "") const
     {
@@ -2631,7 +2449,6 @@ public:
     const char* getStorageQualifierString() const { return GetStorageQualifierString(qualifier.storage); }
     const char* getBuiltInVariableString() const { return GetBuiltInVariableString(qualifier.builtIn); }
     const char* getPrecisionQualifierString() const { return GetPrecisionQualifierString(qualifier.precision); }
-#endif
 
     const TTypeList* getStruct() const { assert(isStruct()); return structure; }
     void setStruct(TTypeList* s) { assert(isStruct()); structure = s; }
@@ -2825,14 +2642,12 @@ public:
                 (typeParameters != nullptr && right.typeParameters != nullptr && *typeParameters == *right.typeParameters));
     }
 
-#ifndef GLSLANG_WEB
     // See if two type's SPIR-V type contents match
     bool sameSpirvType(const TType& right) const
     {
         return ((spirvType == nullptr && right.spirvType == nullptr) ||
                 (spirvType != nullptr && right.spirvType != nullptr && *spirvType == *right.spirvType));
     }
-#endif
 
     // See if two type's elements match in all ways except basic type
     // If mismatch in structure members, return member indices in lpidx and rpidx.
@@ -2877,11 +2692,7 @@ public:
     // See if two types match in all ways (just the actual type, not qualification)
     bool operator==(const TType& right) const
     {
-#ifndef GLSLANG_WEB
         return sameElementType(right) && sameArrayness(right) && sameTypeParameters(right) && sameSpirvType(right);
-#else
-        return sameElementType(right) && sameArrayness(right) && sameTypeParameters(right);
-#endif
     }
 
     bool operator!=(const TType& right) const
@@ -2891,18 +2702,14 @@ public:
 
     unsigned int getBufferReferenceAlignment() const
     {
-#ifndef GLSLANG_WEB
         if (getBasicType() == glslang::EbtReference) {
             return getReferentType()->getQualifier().hasBufferReferenceAlign() ?
                         (1u << getReferentType()->getQualifier().layoutBufferReferenceAlign) : 16u;
         }
-#endif
         return 0;
     }
 
-#ifndef GLSLANG_WEB
     const TSpirvType& getSpirvType() const { assert(spirvType); return *spirvType; }
-#endif
 
 protected:
     // Require consumer to pick between deep copy and shallow copy.
@@ -2916,7 +2723,6 @@ protected:
     {
         shallowCopy(copyOf);
 
-#ifndef GLSLANG_WEB
         // GL_EXT_spirv_intrinsics
         if (copyOf.qualifier.spirvDecorate) {
             qualifier.spirvDecorate = new TSpirvDecorate;
@@ -2927,7 +2733,6 @@ protected:
             spirvType = new TSpirvType;
             *spirvType = *copyOf.spirvType;
         }
-#endif
 
         if (copyOf.arraySizes) {
             arraySizes = new TArraySizes;
@@ -2988,9 +2793,7 @@ protected:
     TString *typeName;          // for structure type name
     TSampler sampler;
     TArraySizes* typeParameters;// nullptr unless a parameterized type; can be shared across types
-#ifndef GLSLANG_WEB
     TSpirvType* spirvType;  // SPIR-V type defined by spirv_type directive
-#endif
 };
 
 } // end namespace glslang

--- a/glslang/Include/Types.h
+++ b/glslang/Include/Types.h
@@ -85,8 +85,6 @@ struct TSampler {   // misnomer now; includes images, textures without sampler, 
     bool      image : 1;  // image, combined should be false
     bool   combined : 1;  // true means texture is combined with a sampler, false means texture with no sampler
     bool    sampler : 1;  // true means a pure sampler, other fields should be clear()
-
-
     unsigned int vectorSize : 3;  // vector return type size.
     // Some languages support structures as sample results.  Storing the whole structure in the
     // TSampler is too large, so there is an index to a separate table.
@@ -807,7 +805,6 @@ public:
         }
     }
 
-
     bool isPerPrimitive() const { return perPrimitiveNV; }
     bool isPerView() const { return perViewNV; }
     bool isTaskMemory() const { return perTaskNV; }
@@ -1084,7 +1081,6 @@ public:
     const TSpirvDecorate& getSpirvDecorate() const { assert(spirvDecorate); return *spirvDecorate; }
     TSpirvDecorate& getSpirvDecorate() { assert(spirvDecorate); return *spirvDecorate; }
     TString getSpirvDecorateQualifierString() const;
-
     bool hasSpecConstantId() const
     {
         // Not the same thing as being a specialization constant, this
@@ -1451,7 +1447,6 @@ public:
     // SPIR-V type defined by spirv_type directive
     TSpirvType* spirvType;
 
-
     bool isCoopmat() const { return coopmat; }
 
     void initType(const TSourceLoc& l)
@@ -1466,7 +1461,6 @@ public:
         typeParameters = nullptr;
         coopmat = false;
         spirvType = nullptr;
-
     }
 
     void initQualifiers(bool global = false)

--- a/glslang/MachineIndependent/Initialize.cpp
+++ b/glslang/MachineIndependent/Initialize.cpp
@@ -7843,12 +7843,12 @@ void TBuiltIns::identifyBuiltIns(int version, EProfile profile, const SpvVersion
             BuiltInVariable("gl_InstanceIndex", EbvInstanceIndex, symbolTable);
         }
 
-#ifdef GLSLANG_WEB
+
         if (spvVersion.vulkan == 0) {
             SpecialQualifier("gl_VertexID",   EvqVertexId,   EbvVertexId,   symbolTable);
             SpecialQualifier("gl_InstanceID", EvqInstanceId, EbvInstanceId, symbolTable);
         }
-#endif
+
 
 #ifndef GLSLANG_WEB
         if (spvVersion.vulkan > 0 && spvVersion.vulkanRelaxed) {

--- a/glslang/MachineIndependent/Initialize.cpp
+++ b/glslang/MachineIndependent/Initialize.cpp
@@ -7844,12 +7844,10 @@ void TBuiltIns::identifyBuiltIns(int version, EProfile profile, const SpvVersion
             BuiltInVariable("gl_InstanceIndex", EbvInstanceIndex, symbolTable);
         }
 
-
         if (spvVersion.vulkan == 0) {
             SpecialQualifier("gl_VertexID",   EvqVertexId,   EbvVertexId,   symbolTable);
             SpecialQualifier("gl_InstanceID", EvqInstanceId, EbvInstanceId, symbolTable);
         }
-
 
 #ifndef GLSLANG_WEB
         if (spvVersion.vulkan > 0 && spvVersion.vulkanRelaxed) {

--- a/glslang/MachineIndependent/Initialize.cpp
+++ b/glslang/MachineIndependent/Initialize.cpp
@@ -4943,6 +4943,7 @@ void TBuiltIns::initialize(int version, EProfile profile, const SpvVersion& spvV
     if (version >= 130 && spvVersion.vulkan == 0)
             stageBuiltins[EShLangVertex].append(
                 "int gl_VertexID;"            // needs qualifier fixed later
+                "int gl_InstanceID;"
                 );
 #endif
 
@@ -5236,19 +5237,19 @@ void TBuiltIns::initialize(int version, EProfile profile, const SpvVersion& spvV
                     );
 #ifndef GLSLANG_WEB
             if (version < 310)
-#endif
                 stageBuiltins[EShLangVertex].append(
                     "highp vec4  gl_Position;"    // needs qualifier fixed later
                     "highp float gl_PointSize;"   // needs qualifier fixed later
                     );
-#ifndef GLSLANG_WEB
             else
+#endif
                 stageBuiltins[EShLangVertex].append(
                     "out gl_PerVertex {"
                         "highp vec4  gl_Position;"    // needs qualifier fixed later
                         "highp float gl_PointSize;"   // needs qualifier fixed later
                     "};"
                     );
+#ifndef GLSLANG_WEB
         }
     }
 

--- a/glslang/MachineIndependent/SpirvIntrinsics.cpp
+++ b/glslang/MachineIndependent/SpirvIntrinsics.cpp
@@ -41,6 +41,7 @@
 #include "../Include/SpirvIntrinsics.h"
 #include "../Include/Types.h"
 #include "ParseHelper.h"
+
 namespace glslang {
 
 bool TSpirvTypeParameter::operator==(const TSpirvTypeParameter& rhs) const

--- a/glslang/MachineIndependent/SpirvIntrinsics.cpp
+++ b/glslang/MachineIndependent/SpirvIntrinsics.cpp
@@ -33,7 +33,6 @@
 // POSSIBILITY OF SUCH DAMAGE.
 //
 
-#ifndef GLSLANG_WEB
 
 //
 // GL_EXT_spirv_intrinsics
@@ -42,7 +41,6 @@
 #include "../Include/SpirvIntrinsics.h"
 #include "../Include/Types.h"
 #include "ParseHelper.h"
-
 namespace glslang {
 
 bool TSpirvTypeParameter::operator==(const TSpirvTypeParameter& rhs) const
@@ -53,6 +51,8 @@ bool TSpirvTypeParameter::operator==(const TSpirvTypeParameter& rhs) const
     assert(type != nullptr);
     return *type == *rhs.type;
 }
+
+#ifndef GLSLANG_WEB
 
 //
 // Handle SPIR-V requirements
@@ -198,77 +198,6 @@ void TQualifier::setSpirvDecorateString(int decoration, const TIntermAggregate* 
     spirvDecorate->decorateStrings[decoration] = extraOperands;
 }
 
-TString TQualifier::getSpirvDecorateQualifierString() const
-{
-    assert(spirvDecorate);
-
-    TString qualifierString;
-
-    const auto appendFloat = [&](float f) { qualifierString.append(std::to_string(f).c_str()); };
-    const auto appendInt = [&](int i) { qualifierString.append(std::to_string(i).c_str()); };
-    const auto appendUint = [&](unsigned int u) { qualifierString.append(std::to_string(u).c_str()); };
-    const auto appendBool = [&](bool b) { qualifierString.append(std::to_string(b).c_str()); };
-    const auto appendStr = [&](const char* s) { qualifierString.append(s); };
-
-    const auto appendDecorate = [&](const TIntermTyped* constant) {
-        if (constant->getAsConstantUnion()) {
-            auto& constArray = constant->getAsConstantUnion()->getConstArray();
-            if (constant->getBasicType() == EbtFloat) {
-                float value = static_cast<float>(constArray[0].getDConst());
-                appendFloat(value);
-            } else if (constant->getBasicType() == EbtInt) {
-                int value = constArray[0].getIConst();
-                appendInt(value);
-            } else if (constant->getBasicType() == EbtUint) {
-                unsigned value = constArray[0].getUConst();
-                appendUint(value);
-            } else if (constant->getBasicType() == EbtBool) {
-                bool value = constArray[0].getBConst();
-                appendBool(value);
-            } else if (constant->getBasicType() == EbtString) {
-                const TString* value = constArray[0].getSConst();
-                appendStr(value->c_str());
-            } else
-                assert(0);
-        } else {
-            assert(constant->getAsSymbolNode());
-            appendStr(constant->getAsSymbolNode()->getName().c_str());
-        }
-    };
-
-    for (auto& decorate : spirvDecorate->decorates) {
-        appendStr("spirv_decorate(");
-        appendInt(decorate.first);
-        for (auto extraOperand : decorate.second) {
-            appendStr(", ");
-            appendDecorate(extraOperand);
-        }
-        appendStr(") ");
-    }
-
-    for (auto& decorateId : spirvDecorate->decorateIds) {
-        appendStr("spirv_decorate_id(");
-        appendInt(decorateId.first);
-        for (auto extraOperand : decorateId.second) {
-            appendStr(", ");
-            appendDecorate(extraOperand);
-        }
-        appendStr(") ");
-    }
-
-    for (auto& decorateString : spirvDecorate->decorateStrings) {
-        appendStr("spirv_decorate_string(");
-        appendInt(decorateString.first);
-        for (auto extraOperand : decorateString.second) {
-            appendStr(", ");
-            appendDecorate(extraOperand);
-        }
-        appendStr(") ");
-    }
-
-    return qualifierString;
-}
-
 //
 // Handle SPIR-V type specifiers
 //
@@ -358,6 +287,79 @@ TSpirvInstruction* TParseContext::mergeSpirvInstruction(const TSourceLoc& loc, T
     return spirvInst1;
 }
 
+#endif // GLSLANG_WEB
+
+TString TQualifier::getSpirvDecorateQualifierString() const
+{
+    assert(spirvDecorate);
+
+    TString qualifierString;
+
+    const auto appendFloat = [&](float f) { qualifierString.append(std::to_string(f).c_str()); };
+    const auto appendInt = [&](int i) { qualifierString.append(std::to_string(i).c_str()); };
+    const auto appendUint = [&](unsigned int u) { qualifierString.append(std::to_string(u).c_str()); };
+    const auto appendBool = [&](bool b) { qualifierString.append(std::to_string(b).c_str()); };
+    const auto appendStr = [&](const char* s) { qualifierString.append(s); };
+
+    const auto appendDecorate = [&](const TIntermTyped* constant) {
+        if (constant->getAsConstantUnion()) {
+            auto& constArray = constant->getAsConstantUnion()->getConstArray();
+            if (constant->getBasicType() == EbtFloat) {
+                float value = static_cast<float>(constArray[0].getDConst());
+                appendFloat(value);
+            } else if (constant->getBasicType() == EbtInt) {
+                int value = constArray[0].getIConst();
+                appendInt(value);
+            } else if (constant->getBasicType() == EbtUint) {
+                unsigned value = constArray[0].getUConst();
+                appendUint(value);
+            } else if (constant->getBasicType() == EbtBool) {
+                bool value = constArray[0].getBConst();
+                appendBool(value);
+            } else if (constant->getBasicType() == EbtString) {
+                const TString* value = constArray[0].getSConst();
+                appendStr(value->c_str());
+            } else
+                assert(0);
+        } else {
+            assert(constant->getAsSymbolNode());
+            appendStr(constant->getAsSymbolNode()->getName().c_str());
+        }
+    };
+
+    for (auto& decorate : spirvDecorate->decorates) {
+        appendStr("spirv_decorate(");
+        appendInt(decorate.first);
+        for (auto extraOperand : decorate.second) {
+            appendStr(", ");
+            appendDecorate(extraOperand);
+        }
+        appendStr(") ");
+    }
+
+    for (auto& decorateId : spirvDecorate->decorateIds) {
+        appendStr("spirv_decorate_id(");
+        appendInt(decorateId.first);
+        for (auto extraOperand : decorateId.second) {
+            appendStr(", ");
+            appendDecorate(extraOperand);
+        }
+        appendStr(") ");
+    }
+
+    for (auto& decorateString : spirvDecorate->decorateStrings) {
+        appendStr("spirv_decorate_string(");
+        appendInt(decorateString.first);
+        for (auto extraOperand : decorateString.second) {
+            appendStr(", ");
+            appendDecorate(extraOperand);
+        }
+        appendStr(") ");
+    }
+
+    return qualifierString;
+}
+
 } // end namespace glslang
 
-#endif // GLSLANG_WEB
+


### PR DESCRIPTION
Updated glslang to work on iOS and MacOS. Changed Types.h to not be stripped out based on GLSLANG_WEB flag, the simplifications made to the type information are causing confusion when compiling to languages require samplers and textures to be separated.  