### PR TITLE
Fix compiler error on GCC 11.4

### DIFF
--- a/SPIRV/SpvBuilder.cpp
+++ b/SPIRV/SpvBuilder.cpp
@@ -41,6 +41,7 @@
 
 #include <cassert>
 #include <cstdlib>
+#include <cstring>
 
 #include <unordered_set>
 #include <algorithm>


### PR DESCRIPTION
Fixed compiler error when compiling using modern gcc on Linux.