### PR TITLE
Suppress UBSan enum check on SPIR-V mask bit-combining operators

### DIFF
--- a/SPIRV/spirv.hpp
+++ b/SPIRV/spirv.hpp
@@ -2681,6 +2681,14 @@ inline void HasResultAndType(Op opcode, bool *hasResult, bool *hasResultType) {
 #endif /* SPV_ENABLE_UTILITY_CODE */
 
 // Overload bitwise operators for mask bit combining
+//
+// Bit-combining operations on SPIR-V mask enums routinely produce values that
+// are not among the individual enumerators (e.g. `~MaskX` or `A | B`). Under
+// -fsanitize=enum this is diagnosed as UB. Suppress the check on just these
+// operator functions; the pattern is intentional.
+#if defined(__clang__)
+#pragma clang attribute push (__attribute__((no_sanitize("enum"))), apply_to = function)
+#endif
 
 inline ImageOperandsMask operator|(ImageOperandsMask a, ImageOperandsMask b) { return ImageOperandsMask(unsigned(a) | unsigned(b)); }
 inline ImageOperandsMask operator&(ImageOperandsMask a, ImageOperandsMask b) { return ImageOperandsMask(unsigned(a) & unsigned(b)); }
@@ -2722,6 +2730,10 @@ inline FragmentShadingRateMask operator|(FragmentShadingRateMask a, FragmentShad
 inline FragmentShadingRateMask operator&(FragmentShadingRateMask a, FragmentShadingRateMask b) { return FragmentShadingRateMask(unsigned(a) & unsigned(b)); }
 inline FragmentShadingRateMask operator^(FragmentShadingRateMask a, FragmentShadingRateMask b) { return FragmentShadingRateMask(unsigned(a) ^ unsigned(b)); }
 inline FragmentShadingRateMask operator~(FragmentShadingRateMask a) { return FragmentShadingRateMask(~unsigned(a)); }
+
+#if defined(__clang__)
+#pragma clang attribute pop
+#endif
 
 }  // end namespace spv
 


### PR DESCRIPTION
## Problem

The `operator|` / `operator&` / `operator^` / `operator~` overloads in `SPIRV/spirv.hpp` exist specifically to bit-combine mask-enum values. By construction the results are usually NOT one of the individually-declared enumerators — `A | B`, `~A`, etc. produce composite bit patterns that no enumerator matches on its own.

Under `-fsanitize=enum`, creating an enum value whose bit pattern isn't a valid enumerator is reported as UB, e.g. from BabylonNative's macOS sanitized CI:

```
SPIRV/spirv.hpp:2710:124: runtime error:
  load of value 4294967287, which is not a valid value for type 'MemoryAccessMask'
```

These diagnostics were previously printed to stderr and ignored. With BabylonNative now running with `-fno-sanitize-recover=all`, they become hard aborts and block the build.

## Fix

Wrap only the mask bit-combining operator block (`spirv.hpp:2685-2724`) with `#pragma clang attribute push(__attribute__((no_sanitize("enum"))), apply_to = function)` / `pop`. The pattern is intentional and well-defined at the bit level; the suppression is scoped to exactly the functions where the design requires it, so the rest of the codebase continues to benefit from UBSan's enum check.

Conditioned on `__clang__`; other compilers (GCC, MSVC) are unaffected.

[Created by Copilot on behalf of @bghgary]
